### PR TITLE
Update regex in References.java to stop at the first colon for player name

### DIFF
--- a/src/main/java/com/slimtrade/core/References.java
+++ b/src/main/java/com/slimtrade/core/References.java
@@ -20,7 +20,7 @@ public class References {
     // Regex
     public static final String REGEX_CLIENT_DATA = "((?<date>\\d{4}\\/\\d{2}\\/\\d{2}) (?<time>\\d{2}:\\d{2}:\\d{2}))?.*] ";
     public static final String REGEX_MESSAGE_PREFIX = REGEX_CLIENT_DATA + "@(?<messageType>От кого|\\S+) (?<guildName><.+> )?(?<playerName>.+):(\\s+)(?<message>";
-    public static final String REGEX_CLIENT_CHAT_PREFIX = REGEX_CLIENT_DATA + "(?<messageType>#|[$]|От кого|@[^\\s<>]+) ?(?<guildName><.+> )?(?<playerName>.+):(\\s+)(?<message>.+";
+    public static final String REGEX_CLIENT_CHAT_PREFIX = REGEX_CLIENT_DATA + "(?<messageType>#|[$]|От кого|@[^\\s<>]+) ?(?<guildName><.+> )?(?<playerName>[^:]+):(\\s+)(?<message>.+";
     public static final String REGEX_CLIENT_META_PREFIX = REGEX_CLIENT_DATA + "(: )?(?<message>.+";
     public static final String REGEX_QUICK_PASTE_PREFIX = "@(?<guildName><.+> )?(?<playerName>.+)(\\s+)(?<message>";
     public static final String REGEX_JOINED_AREA_PREFIX = "(.+ : (?<playerName>.+) ";


### PR DESCRIPTION
Updated chat parsing regex to look for non-colon characters after the player's name rather than any character.

FIXES #70 