### PR TITLE
feat: add support for linux x11 via xdotool

### DIFF
--- a/src/main/java/github/zmilla93/core/utility/POEInterface.java
+++ b/src/main/java/github/zmilla93/core/utility/POEInterface.java
@@ -209,7 +209,7 @@ public class POEInterface {
                 break;
             case LINUX:
                 for (String gameClass : linuxGameClasses) {
-                    ProcessBuilder processBuilder = new ProcessBuilder("sh", "-c", "xdotool windowactivate --sync $(xdotool search --onlyvisible --class " + gameClass + ")");
+                    ProcessBuilder processBuilder = new ProcessBuilder("sh", "-c", "xdotool windowactivate --sync $(xdotool search --onlyvisible --class %s)".formatted(gameClass));
                     try {
                         Process process = processBuilder.start();
                         int exitCode = process.waitFor();

--- a/src/main/java/github/zmilla93/core/utility/POEInterface.java
+++ b/src/main/java/github/zmilla93/core/utility/POEInterface.java
@@ -208,14 +208,16 @@ public class POEInterface {
                 }
                 break;
             case LINUX:
+                // Linux X11 using xdotool
                 for (String gameClass : linuxGameClasses) {
-                    ProcessBuilder processBuilder = new ProcessBuilder("sh", "-c", "xdotool windowactivate --sync $(xdotool search --onlyvisible --class %s)".formatted(gameClass));
+                    ProcessBuilder processBuilder = new ProcessBuilder("sh", "-c", "xdotool windowactivate --sync $(xdotool search --onlyvisible --class " + gameClass);
                     try {
                         Process process = processBuilder.start();
                         int exitCode = process.waitFor();
                         if (exitCode == 0) break;
                     } catch (Exception e) {
                         e.printStackTrace();
+                        ZLogger.log(e.getStackTrace());
                     }
                 }
                 break;
@@ -267,8 +269,8 @@ public class POEInterface {
                 NativePoeWindow.setPOEGameWindow(focusedWindow);
             }
             return true;
-       }
-       return false;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
This change adds support for Linux X11 based Desktop Environments with `xdotool`.
The change will fork out a shell `sh` and call `xdotool` as necessary for locating and focusing the appropriate window.
Both `sh` and `xdotool` should be located in `$PATH` which is standard practice, but worth calling out.

A couple caveats worth mentioning based on my testing with Openbox:
1. If you want the overlay to be on the same screen as POE you must run POE in Windowed mode.
2. Fullscreen or Windowed Fullscreen seems to hijack the whole screen in question so always on top doesn't actually work you'll never see it on the same screen, however if you plan to run the overlay on a different screen with POE either of the Fullscreen options that's fine.

@zmilla93 when attempting to locate the POE window in question I'm using the class names, perhaps some people are able to run POE on Linux without Steam (haven't really looked into it), if that's the case then we can adjust this to enumerate based on the window title instead. I would suggest we start with this and see if anybody runs into any issues and adjust only if necessary.
I did try to factorise parts of the code in order to reduce de-duplication, happy to adjust as necessary just let me know.